### PR TITLE
Debugging playback sound in semaphore pipeline

### DIFF
--- a/MobileApps/iOS/Despenso/DespensoUITests/RecordingViewUITests.swift
+++ b/MobileApps/iOS/Despenso/DespensoUITests/RecordingViewUITests.swift
@@ -45,13 +45,15 @@ class RecordingViewUITests: XCTestCase {
         app.buttons["Record my list!"].tap()
         XCTAssertFalse(playButton.isEnabled)
         
+        sleep(2)
+
         app.buttons["Stop recording"].tap()
         XCTAssert(playButton.isEnabled)
-        
+
         playButton.tap()
         XCTAssertFalse(recordButton.isEnabled)
 
-        sleep(1)
+        app.buttons["Stop Playing"].tap()
 
         XCTAssert(recordButton.isEnabled)
         XCTAssert(playButton.exists)

--- a/MobileApps/iOS/Despenso/DespensoUITests/RecordingViewUITests.swift
+++ b/MobileApps/iOS/Despenso/DespensoUITests/RecordingViewUITests.swift
@@ -48,6 +48,14 @@ class RecordingViewUITests: XCTestCase {
         app.buttons["Stop recording"].tap()
         XCTAssert(playButton.isEnabled)
         
+        playButton.tap()
+        XCTAssertFalse(recordButton.isEnabled)
+
+        sleep(1)
+
+        XCTAssert(recordButton.isEnabled)
+        XCTAssert(playButton.exists)
+        
     }
     
     func testPermissionDeniedOnFirstTimeUsage() {


### PR DESCRIPTION
I have found a weird behavior of @semaphoreci when running tests that involve playback of audio files. In this PR is a simple test case that first records audio, writes it to a file and finally plays it back. All through user interaction with the two button based UI (record and play).